### PR TITLE
Fix "illegal object" crash when entering most SanFac rooms

### DIFF
--- a/kalamontee.zil
+++ b/kalamontee.zil
@@ -322,11 +322,11 @@ millennia and cultural gulfs have changed toilet bowl design. The only exit is "
       
 <ROUTINE SANFAC-SOUTH-F (RARG)
 	 <COND (<EQUAL? .RARG ,M-LOOK>
-		<TELL SANFAC-DESC "north." CR>)>>
+		<TELL ,SANFAC-DESC "north." CR>)>>
       
 <ROUTINE SANFAC-NORTH-F (RARG)
 	 <COND (<EQUAL? .RARG ,M-LOOK>
-		<TELL SANFAC-DESC "south." CR>)>>
+		<TELL ,SANFAC-DESC "south." CR>)>>
 
 
 <ROOM DORM-B


### PR DESCRIPTION
It was mentioned on the "Eaten by a Grue" podcast (the Stationfall episode) that your version of Planetfall crashes when entering the SanFacs. I checked, and it's true:

```
>SOUTH
SanFac A
@Attempt to address illegal object 32604.  This is normally fatal.
Fatal error: Illegal object
```

Apparently it's caused by bugs in ```SANFAC-SOUTH-F``` and ```SANFAC-NORTH-F```. This pull request changes two instances of ```SANFAC-DESC``` into ```,SANFAC-DESC```. I'm not sure _exactly_ how the old one worked, but the generated ZAPF code looked like this:

```
	.FUNCT SANFAC-SOUTH-F,RARG
	EQUAL? RARG,M-LOOK \FALSE
	GETP STR?113,SANFAC-DESC >STACK
	PRINT STACK
	CRLF
	RTRUE

	.FUNCT SANFAC-NORTH-F,RARG
	EQUAL? RARG,M-LOOK \FALSE
	GETP STR?114,SANFAC-DESC >STACK
	PRINT STACK
	CRLF
	RTRUE
```

So apparently it was trying to get the ```SANFAC-DESC``` property from an object with the same number as a string constant, or something like that?

After the change, it looks like this:

```
	.FUNCT SANFAC-SOUTH-F,RARG
	EQUAL? RARG,M-LOOK \FALSE
	PRINT SANFAC-DESC
	PRINTR "north."

	.FUNCT SANFAC-NORTH-F,RARG
	EQUAL? RARG,M-LOOK \FALSE
	PRINT SANFAC-DESC
	PRINTR "south."
```

I looked, but didn't find any other similar bugs. Mind you, I haven't played through this version, since I'm enough of a purist to prefer the original. Still, it'd be a shame if it had any game-breaking bugs.
